### PR TITLE
see impact of using upstream command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: sbt "++${{ matrix.scala-version }} scalafmtCheckAll" scalafmtSbtCheck
 
       - name: Run linter
-        run: sbt "++${{ matrix.scala-version }} scalafixCheckAll"
+        run: sbt ++${{ matrix.scala-version }} "scalafixAll --check"
 
       - name: Compile
         run: sbt "++${{ matrix.scala-version }} compile"

--- a/build.sbt
+++ b/build.sbt
@@ -77,9 +77,6 @@ lazy val sttp = module(project) in file("modules/sttp")
 lazy val yaml = module(project) in file("modules/yaml")
 lazy val `zio-config` = module(project) in file("modules/zio-config")
 
-// Workaround for https://github.com/scalacenter/scalafix/issues/1488
-val scalafixCheckAll = taskKey[Unit]("No-arg alias for 'scalafixAll --check'")
-
 lazy val commonSettings = Seq(
   // format: off
   homepage := Some(url("https://github.com/pureconfig/pureconfig")),
@@ -110,7 +107,6 @@ lazy val commonSettings = Seq(
 
   scalafmtOnCompile := true,
   scalafixOnCompile := true,
-  scalafixCheckAll := scalafixAll.toTask(" --check").value,
 
   autoAPIMappings := true,
 


### PR DESCRIPTION
https://github.com/scalacenter/scalafix/issues/1488

`sbt ++${{ scala-version}} "scalafixAll --check"` works better but generates other issues on the Scala 3 axis, as this now gets evaluated in 2-steps (instead of a single command `++ <sv> <command>`):
- the Scala version is set wherever it's possible (as [the `++`'s  `<command>` is optional](https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Switching+Scala+version))
- `scalafixAll --check` runs everywhere (including on projects where the Scala version was not touched, causing obscure dependency errors)